### PR TITLE
add github action to sync live demo deploy branch with main

### DIFF
--- a/.github/workflows/sync-live.yml
+++ b/.github/workflows/sync-live.yml
@@ -1,0 +1,26 @@
+name: Sync live demo branch with main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync main into live
+        run: |
+          git checkout live
+          git merge origin/main --no-edit
+          git push origin live


### PR DESCRIPTION
demo is deployed on `live`, so rebase latest main changes to the branch